### PR TITLE
Parse common incoming messages

### DIFF
--- a/src/downloader/block_id.rs
+++ b/src/downloader/block_id.rs
@@ -1,6 +1,6 @@
 use ethereum_types::H256;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum BlockId {
     Hash(H256),
     Number(u64),

--- a/src/downloader/message_decoder.rs
+++ b/src/downloader/message_decoder.rs
@@ -2,12 +2,19 @@ use crate::downloader::messages::*;
 
 pub fn decode_rlp_message(id: EthMessageId, message_bytes: &[u8]) -> anyhow::Result<Message> {
     let message: Message = match id {
-        EthMessageId::GetBlockHeaders => {
-            Message::GetBlockHeaders(rlp::decode::<GetBlockHeadersMessage>(message_bytes)?)
-        }
         EthMessageId::NewBlockHashes => {
             Message::NewBlockHashes(rlp::decode::<NewBlockHashesMessage>(message_bytes)?)
         }
+        EthMessageId::GetBlockHeaders => {
+            Message::GetBlockHeaders(rlp::decode::<GetBlockHeadersMessage>(message_bytes)?)
+        }
+        EthMessageId::BlockHeaders => {
+            Message::BlockHeaders(rlp::decode::<BlockHeadersMessage>(message_bytes)?)
+        }
+        EthMessageId::NewBlock => Message::NewBlock(rlp::decode::<NewBlockMessage>(message_bytes)?),
+        EthMessageId::NewPooledTransactionHashes => Message::NewPooledTransactionHashes(
+            rlp::decode::<NewPooledTransactionHashesMessage>(message_bytes)?,
+        ),
         _ => anyhow::bail!("decode_rlp_message: unsupported message {:?}", id),
     };
     Ok(message)
@@ -16,8 +23,11 @@ pub fn decode_rlp_message(id: EthMessageId, message_bytes: &[u8]) -> anyhow::Res
 impl rlp::Encodable for Message {
     fn rlp_append(&self, stream: &mut rlp::RlpStream) {
         match self {
-            Message::GetBlockHeaders(message) => message.rlp_append(stream),
             Message::NewBlockHashes(message) => message.rlp_append(stream),
+            Message::GetBlockHeaders(message) => message.rlp_append(stream),
+            Message::BlockHeaders(message) => message.rlp_append(stream),
+            Message::NewBlock(message) => message.rlp_append(stream),
+            Message::NewPooledTransactionHashes(message) => message.rlp_append(stream),
         }
     }
 }
@@ -26,7 +36,7 @@ impl rlp::Encodable for Message {
 mod tests {
     use crate::downloader::{
         message_decoder::decode_rlp_message,
-        messages::{EthMessageId, Message},
+        messages::{BlockHashAndNumber, EthMessageId, Message, NewBlockHashesMessage},
     };
     use ethereum_types::H256;
     use hex_literal::hex;
@@ -41,17 +51,16 @@ mod tests {
         let bytes = rlp::encode(&some_message);
         assert_eq!(&*bytes, expected_bytes);
 
-        if let Message::NewBlockHashes(message) = some_message {
-            assert_eq!(message.ids.len(), 1);
-            assert_eq!(
-                message.ids[0].0,
-                H256(hex!(
-                    "7100614faba6650b53fe0913ed7267bcc968eb362e3df908645a50aa526c72ba"
-                ))
-            );
-            assert_eq!(message.ids[0].1, 10567341);
-        } else {
-            assert!(false, "unexpected message type");
-        }
+        assert_eq!(
+            some_message,
+            Message::NewBlockHashes(NewBlockHashesMessage {
+                ids: vec![BlockHashAndNumber {
+                    hash: H256(hex!(
+                        "7100614faba6650b53fe0913ed7267bcc968eb362e3df908645a50aa526c72ba"
+                    )),
+                    number: 10567341,
+                },],
+            })
+        );
     }
 }

--- a/src/downloader/messages.rs
+++ b/src/downloader/messages.rs
@@ -1,4 +1,5 @@
 use crate::downloader::block_id::BlockId;
+use ethereum::{Block as BlockType, Header as HeaderType};
 use ethereum_types::H256;
 
 #[derive(Debug)]
@@ -20,7 +21,20 @@ pub enum EthMessageId {
     Receipts = 16,
 }
 
-#[derive(rlp_derive::RlpEncodable, rlp_derive::RlpDecodable, Clone, Copy)]
+#[derive(rlp_derive::RlpEncodable, rlp_derive::RlpDecodable, Clone, Copy, PartialEq, Debug)]
+pub struct BlockHashAndNumber {
+    pub hash: H256,
+    pub number: u64,
+}
+
+#[derive(
+    rlp_derive::RlpEncodableWrapper, rlp_derive::RlpDecodableWrapper, Clone, PartialEq, Debug,
+)]
+pub struct NewBlockHashesMessage {
+    pub ids: Vec<BlockHashAndNumber>,
+}
+
+#[derive(rlp_derive::RlpEncodable, rlp_derive::RlpDecodable, Clone, Copy, PartialEq, Debug)]
 pub struct GetBlockHeadersMessage {
     pub request_id: u64,
     pub start_block: BlockId,
@@ -29,25 +43,42 @@ pub struct GetBlockHeadersMessage {
     pub reverse: bool,
 }
 
-#[derive(rlp_derive::RlpEncodable, rlp_derive::RlpDecodable, Clone, Copy)]
-pub struct BlockHashAndNumber(pub H256, pub u64);
-
-#[derive(rlp_derive::RlpEncodableWrapper, rlp_derive::RlpDecodableWrapper, Clone)]
-pub struct NewBlockHashesMessage {
-    pub ids: Vec<BlockHashAndNumber>,
+#[derive(rlp_derive::RlpEncodable, rlp_derive::RlpDecodable, Clone, PartialEq, Debug)]
+pub struct BlockHeadersMessage {
+    pub request_id: u64,
+    pub headers: Vec<HeaderType>,
 }
 
-#[derive(Clone)]
+#[derive(rlp_derive::RlpEncodable, rlp_derive::RlpDecodable, Clone, PartialEq, Debug)]
+pub struct NewBlockMessage {
+    pub block: Box<BlockType>,
+    pub total_difficulty: u64,
+}
+
+#[derive(
+    rlp_derive::RlpEncodableWrapper, rlp_derive::RlpDecodableWrapper, Clone, PartialEq, Debug,
+)]
+pub struct NewPooledTransactionHashesMessage {
+    pub ids: Vec<H256>,
+}
+
+#[derive(Clone, PartialEq, Debug)]
 pub enum Message {
-    GetBlockHeaders(GetBlockHeadersMessage),
     NewBlockHashes(NewBlockHashesMessage),
+    GetBlockHeaders(GetBlockHeadersMessage),
+    BlockHeaders(BlockHeadersMessage),
+    NewBlock(NewBlockMessage),
+    NewPooledTransactionHashes(NewPooledTransactionHashesMessage),
 }
 
 impl Message {
     pub fn eth_id(self: &Message) -> EthMessageId {
         match self {
-            Message::GetBlockHeaders(_) => EthMessageId::GetBlockHeaders,
             Message::NewBlockHashes(_) => EthMessageId::NewBlockHashes,
+            Message::GetBlockHeaders(_) => EthMessageId::GetBlockHeaders,
+            Message::BlockHeaders(_) => EthMessageId::BlockHeaders,
+            Message::NewBlock(_) => EthMessageId::NewBlock,
+            Message::NewPooledTransactionHashes(_) => EthMessageId::NewPooledTransactionHashes,
         }
     }
 }


### PR DESCRIPTION
* BlockHeaders
* NewBlock
* NewPooledTransactionHashes

Note: `Box<BlockType>` is to avoid 
warning: large size difference between variants (this variant is 696 bytes)
