### PR TITLE
SentryClientReactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ ethereum-interfaces = { git = "https://github.com/ledgerwatch/interfaces", featu
 ] }
 ethereum-types = "0.12"
 futures-core = "0.3"
+futures-util = "0.3"
 hex = "0.4"
 hex-literal = "0.3"
 http = "0.2"
@@ -35,6 +36,7 @@ maplit = "1"
 mdbx = { git = "https://github.com/vorot93/mdbx-rs" }
 modular-bitfield = "0.11"
 once_cell = "1"
+parking_lot = "0.11"
 pin-utils = "0.1"
 rand = "0.8"
 rlp = "0.5"
@@ -46,6 +48,7 @@ serde_json = "1"
 sha3 = "0.9"
 string = { git = "https://github.com/vorot93/string", branch = "update-bytes" }
 structopt = "0.3"
+strum = { version = "0.21", features = ["derive"] }
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }

--- a/src/downloader/downloader_impl.rs
+++ b/src/downloader/downloader_impl.rs
@@ -1,15 +1,14 @@
 use crate::downloader::{
     block_id,
     chain_config::{ChainConfig, ChainsConfig},
-    messages,
+    messages::{EthMessageId, GetBlockHeadersMessage, GetBlockHeadersMessageParams, Message},
     opts::Opts,
     sentry_client,
     sentry_client::{PeerFilter, SentryClient},
     sentry_client_impl::SentryClientImpl,
+    sentry_client_reactor::SentryClientReactor,
 };
-
 use tokio_stream::StreamExt;
-use tracing::*;
 
 pub struct Downloader {
     opts: Opts,
@@ -23,7 +22,10 @@ impl Downloader {
         Downloader { opts, chain_config }
     }
 
-    pub async fn run(&self, sentry_opt: Option<Box<dyn SentryClient>>) -> anyhow::Result<()> {
+    pub async fn run(
+        &self,
+        sentry_client_opt: Option<Box<dyn SentryClient>>,
+    ) -> anyhow::Result<()> {
         let status = sentry_client::Status {
             total_difficulty: ethereum_types::U256::zero(),
             best_hash: ethereum_types::H256::zero(),
@@ -31,36 +33,34 @@ impl Downloader {
             max_block: 0,
         };
 
-        let mut sentry = match sentry_opt {
+        let mut sentry_client = match sentry_client_opt {
             Some(v) => v,
             None => Box::new(SentryClientImpl::new(self.opts.sentry_api_addr.clone()).await?),
         };
 
-        sentry.set_status(status).await?;
+        sentry_client.set_status(status).await?;
 
-        let message = messages::Message::GetBlockHeaders(messages::GetBlockHeadersMessage {
-            request_id: 0,
-            start_block: block_id::BlockId::Number(0),
-            limit: 0,
-            skip: 0,
-            reverse: false,
+        let mut sentry = SentryClientReactor::new(sentry_client);
+        sentry.start();
+
+        let message = Message::GetBlockHeaders(GetBlockHeadersMessage {
+            request_id: 1,
+            params: GetBlockHeadersMessageParams {
+                start_block: block_id::BlockId::Number(123),
+                limit: 5,
+                skip: 0,
+                reverse: 0,
+            },
         });
-        sentry.send_message(message, PeerFilter::All).await?;
+        sentry.send_message(message, PeerFilter::All)?;
 
-        let mut stream = sentry.receive_messages().await?;
-        while let Some(message_result) = stream.next().await {
-            match message_result {
-                Ok(message_from_peer) => self.handle_incoming_message(&message_from_peer.message),
-                Err(error) => {
-                    error!("receive message error {}", error);
-                }
-            }
+        let mut stream = sentry.receive_messages(EthMessageId::BlockHeaders)?;
+        while let Some(message) = stream.next().await {
+            tracing::info!("incoming message: {:?}", message.eth_id());
         }
 
-        Ok(())
-    }
+        sentry.stop().await?;
 
-    fn handle_incoming_message(&self, message: &messages::Message) {
-        tracing::info!("incoming message: {:?}", message.eth_id());
+        Ok(())
     }
 }

--- a/src/downloader/downloader_impl.rs
+++ b/src/downloader/downloader_impl.rs
@@ -53,7 +53,7 @@ impl Downloader {
                 reverse: 0,
             },
         });
-        sentry.send_message(message, PeerFilter::All)?;
+        sentry.send_message(message, PeerFilter::All).await?;
 
         let mut stream = sentry.receive_messages(EthMessageId::BlockHeaders)?;
         while let Some(message) = stream.next().await {

--- a/src/downloader/downloader_impl.rs
+++ b/src/downloader/downloader_impl.rs
@@ -9,6 +9,7 @@ use crate::downloader::{
     sentry_client_reactor::SentryClientReactor,
 };
 use tokio_stream::StreamExt;
+use tracing::*;
 
 pub struct Downloader {
     opts: Opts,
@@ -56,7 +57,7 @@ impl Downloader {
 
         let mut stream = sentry.receive_messages(EthMessageId::BlockHeaders)?;
         while let Some(message) = stream.next().await {
-            tracing::info!("incoming message: {:?}", message.eth_id());
+            info!("incoming message: {:?}", message.eth_id());
         }
 
         sentry.stop().await?;

--- a/src/downloader/downloader_impl.rs
+++ b/src/downloader/downloader_impl.rs
@@ -17,10 +17,10 @@ pub struct Downloader {
 }
 
 impl Downloader {
-    pub fn new(opts: Opts, chains_config: ChainsConfig) -> Downloader {
+    pub fn new(opts: Opts, chains_config: ChainsConfig) -> Self {
         let chain_config = chains_config.0[&opts.chain_name].clone();
 
-        Downloader { opts, chain_config }
+        Self { opts, chain_config }
     }
 
     pub async fn run(

--- a/src/downloader/downloader_tests.rs
+++ b/src/downloader/downloader_tests.rs
@@ -11,8 +11,16 @@ fn make_downloader() -> Downloader {
     downloader
 }
 
+fn setup_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+}
+
 #[tokio::test]
 async fn noop() {
+    setup_logging();
+
     let sentry = SentryClientMock::new();
 
     let downloader = make_downloader();

--- a/src/downloader/message_decoder.rs
+++ b/src/downloader/message_decoder.rs
@@ -35,8 +35,12 @@ impl rlp::Encodable for Message {
 #[cfg(test)]
 mod tests {
     use crate::downloader::{
+        block_id::BlockId,
         message_decoder::decode_rlp_message,
-        messages::{BlockHashAndNumber, EthMessageId, Message, NewBlockHashesMessage},
+        messages::{
+            BlockHashAndNumber, EthMessageId, GetBlockHeadersMessage, GetBlockHeadersMessageParams,
+            Message, NewBlockHashesMessage,
+        },
     };
     use ethereum_types::H256;
     use hex_literal::hex;
@@ -60,6 +64,56 @@ mod tests {
                     )),
                     number: 10567341,
                 },],
+            })
+        );
+    }
+
+    #[test]
+    fn decode_get_block_headers() {
+        let expected_bytes = hex!("ca820457c682270f050580");
+        let result = decode_rlp_message(EthMessageId::GetBlockHeaders, &expected_bytes);
+        let some_message = result.unwrap();
+
+        let bytes = rlp::encode(&some_message);
+        assert_eq!(&*bytes, expected_bytes);
+
+        assert_eq!(
+            some_message,
+            Message::GetBlockHeaders(GetBlockHeadersMessage {
+                request_id: 1111,
+                params: GetBlockHeadersMessageParams {
+                    start_block: BlockId::Number(9999),
+                    limit: 5,
+                    skip: 5,
+                    reverse: 0,
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn decode_get_block_headers_hash() {
+        let expected_bytes = hex!(
+            "e8820457e4a000000000000000000000000000000000000000000000000000000000deadc0de050601"
+        );
+        let result = decode_rlp_message(EthMessageId::GetBlockHeaders, &expected_bytes);
+        let some_message = result.unwrap();
+
+        let bytes = rlp::encode(&some_message);
+        assert_eq!(&*bytes, expected_bytes);
+
+        assert_eq!(
+            some_message,
+            Message::GetBlockHeaders(GetBlockHeadersMessage {
+                request_id: 1111,
+                params: GetBlockHeadersMessageParams {
+                    start_block: BlockId::Hash(H256(hex!(
+                        "00000000000000000000000000000000000000000000000000000000deadc0de"
+                    ))),
+                    limit: 5,
+                    skip: 6,
+                    reverse: 1,
+                },
             })
         );
     }

--- a/src/downloader/messages.rs
+++ b/src/downloader/messages.rs
@@ -2,7 +2,7 @@ use crate::downloader::block_id::BlockId;
 use ethereum::{Block as BlockType, Header as HeaderType};
 use ethereum_types::H256;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, strum::EnumIter)]
 pub enum EthMessageId {
     Status = 0,
     NewBlockHashes = 1,

--- a/src/downloader/messages.rs
+++ b/src/downloader/messages.rs
@@ -2,7 +2,7 @@ use crate::downloader::block_id::BlockId;
 use ethereum::{Block as BlockType, Header as HeaderType};
 use ethereum_types::H256;
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum EthMessageId {
     Status = 0,
     NewBlockHashes = 1,

--- a/src/downloader/messages.rs
+++ b/src/downloader/messages.rs
@@ -37,10 +37,15 @@ pub struct NewBlockHashesMessage {
 #[derive(rlp_derive::RlpEncodable, rlp_derive::RlpDecodable, Clone, Copy, PartialEq, Debug)]
 pub struct GetBlockHeadersMessage {
     pub request_id: u64,
+    pub params: GetBlockHeadersMessageParams,
+}
+
+#[derive(rlp_derive::RlpEncodable, rlp_derive::RlpDecodable, Clone, Copy, PartialEq, Debug)]
+pub struct GetBlockHeadersMessageParams {
     pub start_block: BlockId,
     pub limit: u64,
     pub skip: u64,
-    pub reverse: bool,
+    pub reverse: u8,
 }
 
 #[derive(rlp_derive::RlpEncodable, rlp_derive::RlpDecodable, Clone, PartialEq, Debug)]

--- a/src/downloader/mod.rs
+++ b/src/downloader/mod.rs
@@ -12,5 +12,6 @@ mod sentry_client_mock;
 
 #[cfg(test)]
 mod downloader_tests;
+mod sentry_client_reactor;
 
 pub use self::downloader_impl::Downloader;

--- a/src/downloader/sentry_client.rs
+++ b/src/downloader/sentry_client.rs
@@ -1,4 +1,7 @@
-use crate::downloader::{chain_config::ChainConfig, messages::Message};
+use crate::downloader::{
+    chain_config::ChainConfig,
+    messages::{EthMessageId, Message},
+};
 use async_trait::async_trait;
 use futures_core::Stream;
 
@@ -9,6 +12,7 @@ pub struct Status {
     pub max_block: u64,
 }
 
+#[derive(Debug)]
 pub enum PeerFilter {
     MinBlock(u64),
     PeerId(ethereum_types::H512),
@@ -23,7 +27,7 @@ pub struct MessageFromPeer {
 }
 
 #[async_trait]
-pub trait SentryClient {
+pub trait SentryClient: Send {
     async fn set_status(&mut self, status: Status) -> anyhow::Result<()>;
 
     //async fn penalize_peer(&mut self) -> anyhow::Result<()>;
@@ -33,9 +37,10 @@ pub trait SentryClient {
         &mut self,
         message: Message,
         peer_filter: PeerFilter,
-    ) -> anyhow::Result<()>;
+    ) -> anyhow::Result<u32>;
 
     async fn receive_messages(
         &mut self,
-    ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<MessageFromPeer>> + Unpin>>;
+        filter_ids: &[EthMessageId],
+    ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<MessageFromPeer>> + Unpin + Send>>;
 }

--- a/src/downloader/sentry_client.rs
+++ b/src/downloader/sentry_client.rs
@@ -4,6 +4,7 @@ use crate::downloader::{
 };
 use async_trait::async_trait;
 use futures_core::Stream;
+use std::pin::Pin;
 
 pub struct Status {
     pub total_difficulty: ethereum_types::U256,
@@ -42,5 +43,5 @@ pub trait SentryClient: Send {
     async fn receive_messages(
         &mut self,
         filter_ids: &[EthMessageId],
-    ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<MessageFromPeer>> + Unpin + Send>>;
+    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = anyhow::Result<MessageFromPeer>> + Send>>>;
 }

--- a/src/downloader/sentry_client_mock.rs
+++ b/src/downloader/sentry_client_mock.rs
@@ -3,7 +3,7 @@ use crate::downloader::{
     sentry_client::{MessageFromPeer, PeerFilter, SentryClient, Status},
 };
 use futures_core::Stream;
-use std::collections::HashSet;
+use std::{collections::HashSet, pin::Pin};
 use tokio::sync::broadcast;
 use tokio_stream::{wrappers, StreamExt};
 
@@ -44,8 +44,7 @@ impl SentryClient for SentryClientMock {
     async fn receive_messages(
         &mut self,
         filter_ids: &[EthMessageId],
-    ) -> anyhow::Result<Box<dyn Stream<Item = anyhow::Result<MessageFromPeer>> + Unpin + Send>>
-    {
+    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = anyhow::Result<MessageFromPeer>> + Send>>> {
         let filter_ids_set = filter_ids
             .iter()
             .cloned()
@@ -59,7 +58,7 @@ impl SentryClient for SentryClientMock {
                 })
                 .map(Ok);
 
-            Ok(Box::new(Box::pin(stream)))
+            Ok(Box::pin(stream))
         } else {
             anyhow::bail!("SentryClientMock::receive_messages supports only one receiver")
         }

--- a/src/downloader/sentry_client_reactor.rs
+++ b/src/downloader/sentry_client_reactor.rs
@@ -1,0 +1,210 @@
+use crate::downloader::{
+    messages::{EthMessageId, Message},
+    sentry_client::*,
+};
+use futures_core::Stream;
+use futures_util::TryStreamExt;
+use parking_lot::RwLock;
+use std::{collections::HashMap, sync::Arc};
+use strum::IntoEnumIterator;
+use tokio::{
+    sync::{broadcast, mpsc},
+    task::JoinHandle,
+};
+use tokio_stream::{
+    wrappers::{errors::BroadcastStreamRecvError, BroadcastStream},
+    StreamExt,
+};
+
+pub struct SentryClientReactor {
+    send_message_sender: mpsc::UnboundedSender<SendMessageCommand>,
+    receive_messages_senders: Arc<RwLock<HashMap<EthMessageId, broadcast::Sender<Message>>>>,
+    event_loop: Option<SentryClientReactorEventLoop>,
+    event_loop_handle: Option<JoinHandle<()>>,
+    stop_signal_sender: mpsc::Sender<()>,
+}
+
+struct SentryClientReactorEventLoop {
+    sentry: Box<dyn SentryClient>,
+    send_message_receiver: mpsc::UnboundedReceiver<SendMessageCommand>,
+    receive_messages_senders: Arc<RwLock<HashMap<EthMessageId, broadcast::Sender<Message>>>>,
+    stop_signal_receiver: mpsc::Receiver<()>,
+}
+
+#[derive(Debug)]
+struct SendMessageCommand {
+    message: Message,
+    peer_filter: PeerFilter,
+}
+
+impl SentryClientReactor {
+    pub fn new(sentry: Box<dyn SentryClient>) -> Self {
+        let (send_message_sender, send_message_receiver) =
+            mpsc::unbounded_channel::<SendMessageCommand>();
+
+        let mut receive_messages_senders =
+            HashMap::<EthMessageId, broadcast::Sender<Message>>::new();
+        for id in EthMessageId::iter() {
+            let (sender, _) = broadcast::channel::<Message>(1024);
+            receive_messages_senders.insert(id, sender);
+        }
+        let receive_messages_senders = Arc::new(RwLock::new(receive_messages_senders));
+
+        let (stop_signal_sender, stop_signal_receiver) = mpsc::channel::<()>(1);
+
+        let event_loop = SentryClientReactorEventLoop {
+            sentry,
+            send_message_receiver,
+            receive_messages_senders: Arc::clone(&receive_messages_senders),
+            stop_signal_receiver,
+        };
+
+        Self {
+            send_message_sender,
+            receive_messages_senders: Arc::clone(&receive_messages_senders),
+            event_loop: Some(event_loop),
+            event_loop_handle: None,
+            stop_signal_sender,
+        }
+    }
+
+    pub fn start(&mut self) {
+        let mut event_loop = self.event_loop.take().unwrap();
+        let handle = tokio::spawn(async move {
+            let result = event_loop.run().await;
+            if let Err(error) = result {
+                tracing::error!("SentryClientReactor loop died: {:?}", error);
+            }
+        });
+        self.event_loop_handle = Some(handle);
+    }
+
+    pub async fn stop(&mut self) -> anyhow::Result<()> {
+        if let Some(handle) = self.event_loop_handle.take() {
+            self.send_stop_signal();
+            handle.await?;
+        }
+        Ok(())
+    }
+
+    fn send_stop_signal(&self) {
+        let result = self.stop_signal_sender.try_send(());
+        if result.is_err() {
+            tracing::warn!("SentryClientReactor stop signal already sent or the loop died itself");
+        }
+    }
+
+    pub fn send_message(&self, message: Message, peer_filter: PeerFilter) -> anyhow::Result<()> {
+        let command = SendMessageCommand {
+            message,
+            peer_filter,
+        };
+        self.send_message_sender
+            .send(command)
+            .map_err(anyhow::Error::new)
+    }
+
+    pub fn receive_messages(
+        &self,
+        filter_id: EthMessageId,
+    ) -> anyhow::Result<Box<dyn Stream<Item = Message> + Unpin + Send>> {
+        let receiver: broadcast::Receiver<Message>;
+        {
+            // release the lock on receive_messages_senders after getting a new receiver
+            let senders = self.receive_messages_senders.read();
+            let sender = senders.get(&filter_id).ok_or_else(|| {
+                anyhow::anyhow!("SentryClientReactor unexpected filter_id {:?}", filter_id)
+            })?;
+
+            receiver = sender.subscribe();
+        }
+
+        let stream = BroadcastStream::new(receiver)
+            .map_err(|error| match error {
+                BroadcastStreamRecvError::Lagged(skipped_count) => {
+                    tracing::warn!(
+                        "SentryClientReactor receiver lagged too far behind, skipping {} messages",
+                        skipped_count
+                    );
+                }
+            })
+            // ignore errors (logged above)
+            .filter_map(|result| result.ok());
+
+        Ok(Box::new(Box::pin(stream)))
+    }
+}
+
+impl Drop for SentryClientReactor {
+    fn drop(&mut self) {
+        if self.event_loop_handle.is_some() {
+            self.send_stop_signal();
+        }
+    }
+}
+
+impl SentryClientReactorEventLoop {
+    async fn run(&mut self) -> anyhow::Result<()> {
+        // subscribe to incoming messages
+        let mut in_stream = self.sentry.receive_messages(&[]).await?;
+
+        loop {
+            tokio::select! {
+                Some(command) = self.send_message_receiver.recv() => {
+                    let send_result = self.sentry.send_message(command.message, command.peer_filter).await;
+                    match send_result {
+                        Ok(sent_peers_count) => {
+                            tracing::debug!("SentryClientReactor.EventLoop sent message to {:?} peers", sent_peers_count);
+                        }
+                        Err(error) => {
+                            tracing::error!("SentryClientReactor.EventLoop sentry.send_message error: {}", error);
+                        }
+                    }
+                }
+                message_result = in_stream.next() => {
+                    match message_result {
+                        Some(Ok(message_from_peer)) => {
+                            let id = message_from_peer.message.eth_id();
+                            tracing::debug!("SentryClientReactor.EventLoop incoming message: {:?}", id);
+
+                            let senders = self.receive_messages_senders.read();
+                            let sender = senders.get(&id)
+                                .ok_or_else(|| anyhow::anyhow!("SentryClientReactor.EventLoop unexpected message id {:?}", id))?;
+                            let send_result = sender.send(message_from_peer.message);
+                            if send_result.is_err() {
+                                tracing::debug!("SentryClientReactor.EventLoop no subscribers for message {:?}, dropping", id);
+                            }
+                        }
+                        Some(Err(error)) => {
+                            tracing::error!("SentryClientReactor.EventLoop receive message error: {}", error);
+                            if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
+                                if io_error.kind() == std::io::ErrorKind::BrokenPipe {
+                                    tracing::info!("SentryClientReactor.EventLoop TODO: need to reconnect in_stream");
+                                }
+                            }
+                        },
+                        None => {
+                            tracing::debug!("SentryClientReactor.EventLoop receive_messages stream ended");
+                            break;
+                        }
+                    }
+                }
+                Some(_) = self.stop_signal_receiver.recv() => {
+                    break;
+                }
+                else => {
+                    break;
+                }
+            }
+        }
+
+        // drop shared senders so that existing receive_messages streams end
+        {
+            let mut senders = self.receive_messages_senders.write();
+            senders.clear();
+        }
+
+        tracing::info!("SentryClientReactor stopped");
+        Ok(())
+    }
+}

--- a/src/downloader/sentry_client_reactor.rs
+++ b/src/downloader/sentry_client_reactor.rs
@@ -90,8 +90,7 @@ impl SentryClientReactor {
     }
 
     fn send_stop_signal(&self) {
-        let result = self.stop_signal_sender.try_send(());
-        if result.is_err() {
+        if self.stop_signal_sender.try_send(()).is_err() {
             warn!("SentryClientReactor stop signal already sent or the loop died itself");
         }
     }
@@ -173,11 +172,11 @@ impl SentryClientReactorEventLoop {
                             let id = message_from_peer.message.eth_id();
                             debug!("SentryClientReactor.EventLoop incoming message: {:?}", id);
 
-                            let senders = self.receive_messages_senders.read();
-                            let sender = senders.get(&id)
-                                .ok_or_else(|| anyhow::anyhow!("SentryClientReactor.EventLoop unexpected message id {:?}", id))?;
-                            let send_result = sender.send(message_from_peer.message);
-                            if send_result.is_err() {
+                            if self.receive_messages_senders
+                                .read()
+                                .get(&id)
+                                .ok_or_else(|| anyhow::anyhow!("SentryClientReactor.EventLoop unexpected message id {:?}", id))?
+                                .send(message_from_peer.message).is_err() {
                                 debug!("SentryClientReactor.EventLoop no subscribers for message {:?}, dropping", id);
                             }
                         }

--- a/src/downloader/sentry_client_reactor.rs
+++ b/src/downloader/sentry_client_reactor.rs
@@ -6,7 +6,7 @@ use anyhow::bail;
 use futures_core::Stream;
 use futures_util::TryStreamExt;
 use parking_lot::RwLock;
-use std::{collections::HashMap, fmt, sync::Arc};
+use std::{collections::HashMap, pin::Pin, sync::Arc};
 use strum::IntoEnumIterator;
 use tokio::{
     sync::{broadcast, mpsc},
@@ -115,7 +115,7 @@ impl SentryClientReactor {
     pub fn receive_messages(
         &self,
         filter_id: EthMessageId,
-    ) -> anyhow::Result<Box<dyn Stream<Item = Message> + Unpin + Send>> {
+    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = Message> + Unpin + Send>>> {
         let receiver: broadcast::Receiver<Message>;
         {
             // release the lock on receive_messages_senders after getting a new receiver
@@ -139,7 +139,7 @@ impl SentryClientReactor {
             // ignore errors (logged above)
             .filter_map(|result| result.ok());
 
-        Ok(Box::new(Box::pin(stream)))
+        Ok(Box::pin(stream))
     }
 }
 


### PR DESCRIPTION
Ability to send and receive messages simultaneously across threads.
send_message and receive_messages are synchronous and don't require a mutable borrowing.
The processing happens inside an event loop task.